### PR TITLE
Change teamleader.eu urls to focus.teamleader.eu

### DIFF
--- a/src/Teamleader.php
+++ b/src/Teamleader.php
@@ -57,7 +57,7 @@ class Teamleader
             $body
         );
 
-        return $this->client->request('POST', 'https://app.teamleader.eu/api/' . $uri, ['form_params' => $formParams]);
+        return $this->client->request('POST', 'https://focus.teamleader.eu/api/' . $uri, ['form_params' => $formParams]);
     }
 
     /**
@@ -65,7 +65,7 @@ class Teamleader
      */
     public function makeV2Request(string $uri, array $body = []) : ResponseInterface
     {
-        return $this->client->request('POST', 'https://api.teamleader.eu/' . $uri, [
+        return $this->client->request('POST', 'https://api.focus.teamleader.eu/' . $uri, [
             'json' => $body,
             'headers' => [
                 'Authorization' => 'Bearer ' . $this->accessToken,
@@ -100,7 +100,7 @@ class Teamleader
             $params['state'] = $state;
         }
 
-        return 'https://app.teamleader.eu/oauth2/authorize?'
+        return 'https://focus.teamleader.eu/oauth2/authorize?'
             . http_build_query($params);
     }
 }


### PR DESCRIPTION
The Teamleader application has been renamed to Teamleader Focus, more info about this can be found [here](https://www.teamleader.eu/blog/new-names-teamleader-focus-orbit). This product name change also means that the application, api, marketplace, etc. have a new home under [focus.teamleader.eu](https://focus.teamleader.eu).

This PR changes the Teamleader URLs in this repo to point to [focus.teamleader.eu](https://focus.teamleader.eu). The switch to these new URLs isn't urgent though, the old URLs will remain available for some time.